### PR TITLE
Option to split the hierarchy into multiple GLTF/GLB files

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,11 @@ Options:
                                       rotation of 90 degrees about the X axis such that the +Z axis
                                       will map to the +Y axis, which is the up-direction of GLTF-
                                       files. Default value is true.
+  --output-gltf-split-level=<uint>    Specify a level in the hierarchy to split the output into
+                                      multiple files, where 0 implies no split. Geometries and
+                                      attributes below the split point are included in the first
+                                      file, while subsequent files while have empty nodes just to
+                                      represent the hierarchy. Default value is 0.
   --group-bounding-boxes              Include wireframe of boundingboxes of groups in output.
   --color-attribute=key               Specify which attributes that contain color, empty key
                                       implies that material id of group is used.

--- a/src/Common.h
+++ b/src/Common.h
@@ -110,4 +110,4 @@ void align(Store* store, Logger logger);
 bool exportJson(Store* store, Logger logger, const char* path);
 bool discardGroups(Store* store, Logger logger, const void* ptr, size_t size);
 bool exportRev(Store* store, Logger logger, const char* path);
-bool exportGLTF(Store* store, Logger logger, const char* path, bool rotateZToY, bool centerModel, bool includeAttributes);
+bool exportGLTF(Store* store, Logger logger, const char* path, size_t splitLevel, bool rotateZToY, bool centerModel, bool includeAttributes);

--- a/src/ExportGLTF.cpp
+++ b/src/ExportGLTF.cpp
@@ -61,7 +61,7 @@ namespace {
     std::vector<Vec3f> tmp3f;
     
     struct {
-      size_t level = 3;   // Level to do splitting
+      size_t level = 0;   // Level to do splitting, 0 for no splitting
       size_t choose = 0;  // Keeping track of which split we are processing
       size_t index = 0;   // Which subtree we are to descend
       bool done = false;  // Set to true when there are no more splits
@@ -792,7 +792,7 @@ namespace {
 }
 
 
-bool exportGLTF(Store* store, Logger logger, const char* path, bool rotateZToY, bool centerModel, bool includeAttributes)
+bool exportGLTF(Store* store, Logger logger, const char* path, size_t splitLevel, bool rotateZToY, bool centerModel, bool includeAttributes)
 {
   Context ctx{
     .logger = logger,
@@ -800,6 +800,7 @@ bool exportGLTF(Store* store, Logger logger, const char* path, bool rotateZToY, 
     .rotateZToY = rotateZToY,
     .includeAttributes = includeAttributes,
   };
+  ctx.split.level = splitLevel;
 
   { // Split into stem and suffix
     size_t o = 0; // offset of last dot

--- a/src/ExportGLTF.cpp
+++ b/src/ExportGLTF.cpp
@@ -770,7 +770,7 @@ namespace {
 #else
     FILE* out = fopen(path, "w");
     if (out == nullptr) {
-      logger(2, "Failed to open %s for writing.", path);
+      ctx.logger(2, "Failed to open %s for writing.", path);
       return false;
     }
 #endif

--- a/src/Parser.h
+++ b/src/Parser.h
@@ -4,4 +4,4 @@
 
 bool parseAtt(Store* store, Logger logger, const void * ptr, size_t size, bool create=false);
 
-bool parseRVM(Store* store, const void * ptr, size_t size);
+bool parseRVM(Store* store, const char* path, const void * ptr, size_t size);

--- a/src/ParserRVM.cpp
+++ b/src/ParserRVM.cpp
@@ -110,7 +110,7 @@ namespace {
     }
   }
 
-  const char* parse_head(Context* ctx, const char* base_ptr, const char* curr_ptr, const char* end_ptr, uint32_t expected_next_chunk_offset)
+  const char* parse_head(Context* ctx, const char* path, const char* base_ptr, const char* curr_ptr, const char* end_ptr, uint32_t expected_next_chunk_offset)
   {
     assert(ctx->group_stack.empty());
     auto * g = ctx->store->newNode(nullptr, Node::Kind::File);
@@ -128,6 +128,7 @@ namespace {
     else {
       g->file.encoding = ctx->store->strings.intern("");
     }
+    g->file.path = ctx->store->strings.intern(path);
 
     if (!verifyOffset(ctx, "HEAD", base_ptr, curr_ptr, expected_next_chunk_offset)) return nullptr;
 
@@ -429,7 +430,7 @@ namespace {
 
 }
 
-bool parseRVM(class Store* store, const void * ptr, size_t size)
+bool parseRVM(class Store* store, const char* path, const void * ptr, size_t size)
 {
   char buf[1024];
   Context ctx = { store,  buf, sizeof(buf) };
@@ -448,7 +449,7 @@ bool parseRVM(class Store* store, const void * ptr, size_t size)
     store->setErrorString(buf);
     return false;
   }
-  curr_ptr = parse_head(&ctx, base_ptr, curr_ptr, end_ptr, expected_next_chunk_offset);
+  curr_ptr = parse_head(&ctx, path, base_ptr, curr_ptr, end_ptr, expected_next_chunk_offset);
   if (curr_ptr == nullptr) return false;
 
   curr_ptr = parse_chunk_header(chunk_id, expected_next_chunk_offset, dunno, curr_ptr, end_ptr);

--- a/src/Store.h
+++ b/src/Store.h
@@ -221,6 +221,7 @@ struct Node
       const char* date;
       const char* user;
       const char* encoding;
+      const char* path;
     } file;
     struct {
       ListHeader<Color> colors;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -160,6 +160,11 @@ Options:
                                       rotation of 90 degrees about the X axis such that the +Z axis
                                       will map to the +Y axis, which is the up-direction of GLTF-
                                       files. Default value is true.
+  --output-gltf-split-level=<uint>    Specify a level in the hierarchy to split the output into
+                                      multiple files, where 0 implies no split. Geometries and
+                                      attributes below the split point are included in the first
+                                      file, while subsequent files while have empty nodes just to
+                                      represent the hierarchy. Default value is 0.
   --group-bounding-boxes              Include wireframe of boundingboxes of groups in output.
   --color-attribute=key               Specify which attributes that contain color, empty key
                                       implies that material id of group is used.
@@ -214,6 +219,7 @@ int main(int argc, char** argv)
   bool output_gltf_rotate_z_to_y = true;
   bool output_gltf_center = false;
   bool output_gltf_attributes = true;
+  size_t output_gltf_split_level = 0;
 
   std::string output_rev;
   std::string output_obj_stem;
@@ -281,6 +287,10 @@ int main(int argc, char** argv)
         }
         else if (key == "--output-gltf-attributes") {
           output_gltf_attributes = parseBool(logger, arg, val);
+          continue;
+        }
+        else if (key == "--output-gltf-split-level") {
+          output_gltf_split_level = std::stoul(val);
           continue;
         }
         else if (key == "--color-attribute") {
@@ -481,12 +491,13 @@ int main(int argc, char** argv)
     auto time0 = std::chrono::high_resolution_clock::now();
     if (exportGLTF(store, logger,
                    output_gltf.c_str(),
+                   output_gltf_split_level,
                    output_gltf_rotate_z_to_y,
                    output_gltf_center,
                    output_gltf_attributes))
     {
       long long e = std::chrono::duration_cast<std::chrono::milliseconds>((std::chrono::high_resolution_clock::now() - time0)).count();
-      logger(0, "Exported gltf into %s (%lldms)", output_gltf.c_str(), e);
+      logger(0, "Exported gltf in %lldms", e);
     }
     else {
       logger(2, "Failed to export gltf into %s", output_gltf.c_str());

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -177,7 +177,7 @@ Post bug reports or questions at https://github.com/cdyk/rvmparser
   {
     std::string lower;
     for (const char c : value) {
-      lower.push_back(std::tolower(c));
+      lower.push_back(static_cast<char>(std::tolower(c)));
     }
     if (lower == "true" || lower == "1" || lower == "yes") {
       return true;
@@ -308,11 +308,11 @@ int main(int argc, char** argv)
     }
 
     auto arg_lc = arg;
-    for (auto & c : arg_lc) c = std::tolower(c);
+    for (auto & c : arg_lc) c = static_cast<char>(std::tolower(c));
 
     // parse rvm file
     if (arg_lc.rfind(".rvm") != std::string::npos) {
-      if (processFile(arg, [store](const void * ptr, size_t size) { return parseRVM(store, ptr, size); }))
+      if (processFile(arg, [store, arg](const void * ptr, size_t size) { return parseRVM(store, arg.c_str(), ptr, size); }))
       {
         fprintf(stderr, "Successfully parsed %s\n", arg.c_str());
       }


### PR DESCRIPTION
New option --output-gltf-split-level=<uint>.

If this is nonzero, the hierarchy is split at this level putting each subtree into its own gltf file.

The hierarchy below the split point is included in all files, but only the first file has attributes and geometries for this shared hierarchy.

Implements #48 .