### PR TITLE
fix for when base radius is 0 on sphere based shapes

### DIFF
--- a/src/TriangulationFactory.cpp
+++ b/src/TriangulationFactory.cpp
@@ -1004,6 +1004,11 @@ Triangulation* TriangulationFactory::cylinder(Arena* arena, const Geometry* geo,
 
 Triangulation* TriangulationFactory::sphereBasedShape(Arena* arena, const Geometry* geo, float radius, float arc, float shift_z, float scale_z, float scale)
 {
+
+  if (scale_z == INFINITY) {
+    scale_z = 0;
+  }
+
   unsigned segments = sagittaBasedSegmentCount(twopi, radius, scale);
   unsigned samples = segments;  // Assumed to be closed
 
@@ -1015,6 +1020,8 @@ Triangulation* TriangulationFactory::sphereBasedShape(Arena* arena, const Geomet
     arc = pi;
     is_sphere = true;
   }
+
+
 
   unsigned min_rings = 3;// arc <= half_pi ? 2 : 3;
   unsigned rings = unsigned(std::max(float(min_rings), scale_z * samples*arc*(1.f / twopi)));

--- a/src/TriangulationFactory.cpp
+++ b/src/TriangulationFactory.cpp
@@ -1005,7 +1005,7 @@ Triangulation* TriangulationFactory::cylinder(Arena* arena, const Geometry* geo,
 Triangulation* TriangulationFactory::sphereBasedShape(Arena* arena, const Geometry* geo, float radius, float arc, float shift_z, float scale_z, float scale)
 {
 
-  if (scale_z == INFINITY) {
+  if (!std::isfinite(scale_z)) {
     scale_z = 0;
   }
 


### PR DESCRIPTION

Issue I found while making my rvm splitter.
First though it was something I had done wrong, but when I exported the single site the issue reoccurred.
With the fix its able to parse the files again.

Maybe setting it to scale 1 is more correct ?

Tok and exported the element as text also, so you could see the issue


![image](https://user-images.githubusercontent.com/94840334/232683751-39d8cc67-e3a8-498f-8d7a-ab21a706fcef.png)
