### PR TITLE
Add parserREV for .rev/.txt support and improve parserRVM error handling

### DIFF
--- a/msvc15/rvmparser.vcxproj
+++ b/msvc15/rvmparser.vcxproj
@@ -138,9 +138,9 @@
       <FunctionLevelLinking>true</FunctionLevelLinking>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <SDLCheck>true</SDLCheck>
-      <PreprocessorDefinitions>FOONDEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>FOONDEBUG;_CONSOLE;_AMD64_;_CRT_SECURE_NO_WARNINGS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <ConformanceMode>true</ConformanceMode>
-      <AdditionalIncludeDirectories>$(ProjectDir)..\libs\libtess2\include;$(ProjectDir)..\libs\rapidjson\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>$(ProjectDir)..\libs\libtess2\include;$(ProjectDir)..\libs\rapidjson\include;$(ProjectDir)..\..\Hoops\HOOPS_3DF_2910\Dev_Tools\hoops_3dgs\source;$(ProjectDir)..\..\Hoops\HOOPS_3DF_2910\Dev_Tools\hoops_mvo\source;$(ProjectDir)..\..\Hoops\HOOPS_3DF_2910\Dev_Tools\base_stream\source\stream_common;$(ProjectDir)..\..\Hoops\HOOPS_3DF_2910\Dev_Tools\base_stream\source;$(ProjectDir)..\..\Hoops\HOOPS_3DF_2910\Dev_Tools\hoops_stream\source;$(ProjectDir)..\..\Hoops\HOOPS_3DF_2910\Dev_Tools\utility\source;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <LanguageStandard>stdcpp20</LanguageStandard>
     </ClCompile>
     <Link>
@@ -148,6 +148,9 @@
       <EnableCOMDATFolding>true</EnableCOMDATFolding>
       <OptimizeReferences>true</OptimizeReferences>
       <GenerateDebugInformation>true</GenerateDebugInformation>
+      <AdditionalLibraryDirectories>$(ProjectDir)..\..\Hoops\HOOPS_3DF_2930\Dev_Tools\hoops_3dgs\lib\nt_x64_v142;$(ProjectDir)..\..\Hoops\HOOPS_3DF_2930\Dev_Tools\hoops_mvo\lib\nt_x64_v142;$(ProjectDir)..\..\Hoops\HOOPS_3DF_2930\Dev_Tools\hoops_stream\lib\nt_x64_v142;$(ProjectDir)..\..\Hoops\HOOPS_3DF_2930\Dev_Tools\utility\lib\nt_x64_v142;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
+      <AdditionalDependencies>hoops.lib;hoops_stream.lib;hoops_mvo_mgk.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <IgnoreAllDefaultLibraries>false</IgnoreAllDefaultLibraries>
     </Link>
   </ItemDefinitionGroup>
   <ItemGroup>
@@ -168,6 +171,7 @@
     <ClCompile Include="..\src\DiscardGroups.cpp" />
     <ClCompile Include="..\src\DumpNames.cpp" />
     <ClCompile Include="..\src\ExportGLTF.cpp" />
+    <ClCompile Include="..\src\ExportHsf.cpp" />
     <ClCompile Include="..\src\ExportJson.cpp" />
     <ClCompile Include="..\src\ExportObj.cpp" />
     <ClCompile Include="..\src\ExportRev.cpp" />
@@ -233,6 +237,7 @@
     <ClInclude Include="..\src\Colorizer.h" />
     <ClInclude Include="..\src\Common.h" />
     <ClInclude Include="..\src\DumpNames.h" />
+    <ClInclude Include="..\src\ExportHsf.h" />
     <ClInclude Include="..\src\ExportObj.h" />
     <ClInclude Include="..\src\Flatten.h" />
     <ClInclude Include="..\src\LinAlg.h" />

--- a/msvc15/rvmparser.vcxproj
+++ b/msvc15/rvmparser.vcxproj
@@ -176,6 +176,7 @@
     <ClCompile Include="..\src\LinAlgOps.cpp" />
     <ClCompile Include="..\src\main.cpp" />
     <ClCompile Include="..\src\ParserAtt.cpp" />
+    <ClCompile Include="..\src\parserREV.cpp" />
     <ClCompile Include="..\src\ParserRVM.cpp" />
     <ClCompile Include="..\src\Store.cpp" />
     <ClCompile Include="..\src\Tessellator.cpp" />
@@ -237,6 +238,7 @@
     <ClInclude Include="..\src\LinAlg.h" />
     <ClInclude Include="..\src\LinAlgOps.h" />
     <ClInclude Include="..\src\Parser.h" />
+    <ClInclude Include="..\src\parserREV.h" />
     <ClInclude Include="..\src\StoreVisitor.h" />
     <ClInclude Include="..\src\Store.h" />
     <ClInclude Include="..\src\Tessellator.h" />

--- a/msvc15/rvmparser.vcxproj.filters
+++ b/msvc15/rvmparser.vcxproj.filters
@@ -196,6 +196,9 @@
     <ClInclude Include="..\libs\rapidjson\include\rapidjson\msinttypes\stdint.h">
       <Filter>rapidjson\msinttypes</Filter>
     </ClInclude>
+    <ClInclude Include="..\src\parserREV.h">
+      <Filter>src</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="..\src\main.cpp">
@@ -283,6 +286,9 @@
       <Filter>src</Filter>
     </ClCompile>
     <ClCompile Include="..\src\FlattenRegex.cpp">
+      <Filter>src</Filter>
+    </ClCompile>
+    <ClCompile Include="..\src\parserREV.cpp">
       <Filter>src</Filter>
     </ClCompile>
   </ItemGroup>

--- a/msvc15/rvmparser.vcxproj.filters
+++ b/msvc15/rvmparser.vcxproj.filters
@@ -199,6 +199,9 @@
     <ClInclude Include="..\src\parserREV.h">
       <Filter>src</Filter>
     </ClInclude>
+    <ClInclude Include="..\src\ExportHsf.h">
+      <Filter>src</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="..\src\main.cpp">
@@ -289,6 +292,9 @@
       <Filter>src</Filter>
     </ClCompile>
     <ClCompile Include="..\src\parserREV.cpp">
+      <Filter>src</Filter>
+    </ClCompile>
+    <ClCompile Include="..\src\ExportHsf.cpp">
       <Filter>src</Filter>
     </ClCompile>
   </ItemGroup>

--- a/src/ExportHsf.cpp
+++ b/src/ExportHsf.cpp
@@ -1,0 +1,227 @@
+#include "ExportHsf.h"
+#include <string>
+#include "LinAlgOps.h"
+#include "debugapi.h"
+
+#include "HStream.h"
+#include "stream_common/BStream.h"
+
+ExportHsf::ExportHsf(const char* path) : m_modelKey(INVALID_KEY), m_savePath(path)
+{
+	HBaseModel* baseModel = new HBaseModel();
+	HC_Open_Segment_By_Key(baseModel->GetModelKey());
+	{
+		m_modelKey = HC_Open_Segment("");
+		{
+			HC_Set_Heuristics("static model=on");
+			HC_Set_Visibility("geometry=on");
+		}HC_Close_Segment();
+	}HC_Close_Segment();
+}
+ExportHsf::~ExportHsf()
+{
+}
+void ExportHsf::beginFile(Node* group)
+{
+	HC_Open_Segment_By_Key(m_modelKey);
+
+
+}
+
+void ExportHsf::endFile()
+{
+    HTK_Write_Stream_File(m_savePath.c_str(), TK_Full_Resolution);
+	HC_Close_Segment();
+}
+
+void ExportHsf::beginModel(Node* group)
+{
+	HC_Open_Segment("");
+	std::string pjtName = "project=" + std::string(group->model.project);
+	std::string modelName = "name=" + std::string(group->model.name);
+
+	HC_Set_User_Options(pjtName.c_str());
+	HC_Set_User_Options(modelName.c_str());
+}
+
+void ExportHsf::endModel()
+{
+	HC_Close_Segment();
+}
+
+void ExportHsf::beginGroup(Node* group)
+{
+	HC_Open_Segment("");
+
+}
+
+void ExportHsf::EndGroup()
+{
+	HC_Close_Segment();
+}
+
+void ExportHsf::attribute(const char* key, const char* val)
+{
+	std::string keyString = key;
+	std::string valueString = val;
+	std::string setString = keyString + "=" + valueString;
+	HC_Set_User_Options(setString.c_str());
+}
+
+void ExportHsf::beginAttributes(Node* container)
+{
+	//Attribute* beginRef = container->attributes.first;
+	//Attribute* endRef = container->attributes.last;
+	////std::string setString = "";
+	//while (beginRef != endRef) {
+	//	std::string keyString;
+	//	std::string valueString;
+	//	keyString = beginRef->key;
+	//	valueString = beginRef->val;
+	//	std::string setString = keyString + "=" + valueString;
+	//	HC_Set_User_Options(setString.c_str());
+	//	beginRef = beginRef->next;
+	//}
+}
+
+void ExportHsf::geometry(Geometry* geometry)
+{
+    float scale = 1.f;
+
+    // color
+    uint32_t colorId = (geometry->color << 8) | geometry->transparency;
+    if (!m_definedColors.get((uint64_t(colorId) << 1) | 1)) {
+        m_definedColors.insert(((uint64_t(colorId) << 1) | 1), 1);
+
+        double r = (1.0 / 255.0) * ((geometry->color >> 16) & 0xFF);
+        double g = (1.0 / 255.0) * ((geometry->color >> 8) & 0xFF);
+        double b = (1.0 / 255.0) * ((geometry->color) & 0xFF);
+
+        char chTransmission[MVO_SMALL_BUFFER_SIZE];
+        sprintf(chTransmission, "faces = (transmission = (R=%f G=%f B=%f))",
+            r,
+            g,
+            b);
+
+        HC_Set_Color(chTransmission);
+    }
+
+    switch (geometry->kind)
+    {
+ //   case Geometry::Kind::Pyramid:
+ //       break;
+ //   case Geometry::Kind::Box:
+ //       break;
+ //   case Geometry::Kind::RectangularTorus:
+ //       break;
+ //   case Geometry::Kind::CircularTorus:
+ //       break;
+ //   case Geometry::Kind::EllipticalDish:
+ //       break;
+ //   case Geometry::Kind::SphericalDish:
+ //       break;
+	//case Geometry::Kind::Snout:
+ //       break;
+	//case Geometry::Kind::Cylinder:
+ //       break;
+	//case Geometry::Kind::Sphere:
+ //       break;
+    //case Geometry::Kind::FacetGroup:
+    //    break;
+	case Geometry::Kind::Line:
+        auto a = scale * mul(geometry->M_3x4, makeVec3f(geometry->line.a, 0, 0));
+        auto b = scale * mul(geometry->M_3x4, makeVec3f(geometry->line.b, 0, 0));
+		HC_Insert_Line(a.x, a.y, a.z, b.x, b.y, b.z);  
+        break;
+	default:
+	{
+        float scale = 1.f;
+        std::vector<HPoint> localVectorPoints;
+        std::vector<HPoint> localNormalPoints;
+        std::vector<int> localIndices;
+        if (geometry->kind == Geometry::Kind::Line) {
+            auto a = scale * mul(geometry->M_3x4, makeVec3f(geometry->line.a, 0, 0));
+            auto b = scale * mul(geometry->M_3x4, makeVec3f(geometry->line.b, 0, 0));
+
+            off_v += 2;
+        }
+        else {
+            assert(geometry->triangulation);
+            auto* tri = geometry->triangulation;
+
+            if (tri->indices != 0) {
+                //fprintf(out, "g\n");
+                if (geometry->triangulation->error != 0.f) {
+                    OutputDebugStringA(("Triangulation Error " + std::to_string(geometry->triangulation->error) + "\n").c_str());
+                }
+                for (size_t i = 0; i < 3 * tri->vertices_n; i += 3) {
+
+                    auto p = scale * mul(geometry->M_3x4, makeVec3f(tri->vertices + i));
+                    Vec3f n = normalize(mul(makeMat3f(geometry->M_3x4.data), makeVec3f(tri->normals + i)));
+                    if (!std::isfinite(n.x) || !std::isfinite(n.y) || !std::isfinite(n.z)) {
+                        n = makeVec3f(1.f, 0.f, 0.f);
+                    }
+                    HPoint cPoint = HPoint(p.x, p.y, p.z);
+                    localVectorPoints.push_back(cPoint);
+                    HPoint cNormal = HPoint(n.x, n.y, n.z);
+                    localNormalPoints.push_back(cNormal);
+                }
+                if (tri->texCoords) {
+                    /*for (size_t i = 0; i < tri->vertices_n; i++) {
+                        const Vec2f vt = makeVec2f(tri->texCoords + 2 * i);
+                        fprintf(out, "vt %f %f\n", vt.x, vt.y);
+                    }*/
+                }  //texture not required.
+                else {
+                    /*for (size_t i = 0; i < tri->vertices_n; i++) {
+                        auto p = scale * mul(geometry->M_3x4, makeVec3f(tri->vertices + 3 * i));
+                        fprintf(out, "vt %f %f\n", 0 * p.x, 0 * p.y);
+                    }*/
+
+                    for (size_t i = 0; i < 3 * tri->triangles_n; i += 3) {
+                        auto a = tri->indices[i + 0];
+                        auto b = tri->indices[i + 1];
+                        auto c = tri->indices[i + 2];
+                        localIndices.push_back(3);
+                        localIndices.push_back(a);
+                        localIndices.push_back(b);
+                        localIndices.push_back(c);
+
+                        /*std::string debugString;
+                        debugString = "indices 1: " + std::to_string(a + off_v) + "/" + std::to_string(a + off_t) + "/" + std::to_string(a + off_n);
+                        debugString += "indices 2: " + std::to_string(b + off_v) + "/" + std::to_string(b + off_t) + "/" + std::to_string(b + off_n);
+                        debugString += "indices 3: " + std::to_string(c + off_v) + "/" + std::to_string(c + off_t) + "/" + std::to_string(c + off_n);
+                        OutputDebugStringA(debugString.c_str());*/
+                    }
+                }
+
+                off_v += tri->vertices_n;
+                off_n += tri->vertices_n;
+                off_t += tri->vertices_n;
+            }
+        }
+
+        int* faces = new int[localIndices.size()];
+        HPoint* points = new HPoint[localVectorPoints.size()];
+        for (size_t i = 0; i < localVectorPoints.size(); ++i) {
+            points[i] = localVectorPoints[i];
+        }
+        for (size_t i = 0; i < localIndices.size(); ++i) {
+            faces[i] = localIndices[i];
+        }
+        int verticesCount = static_cast<int>(localVectorPoints.size());
+        int indiceCount = static_cast<int>(localIndices.size());
+        HC_KEY shell = HC_Insert_Shell(verticesCount, points, indiceCount, faces);
+        //HC_Close_Segment();
+        delete[]faces;
+        delete[]points;
+	
+	}
+        break;
+
+    }
+
+    
+
+
+}

--- a/src/ExportHsf.h
+++ b/src/ExportHsf.h
@@ -1,0 +1,57 @@
+#pragma once
+#include <cstdio>
+#include "Common.h"
+#include "StoreVisitor.h"
+
+#include <hc.h>
+#include <HBaseModel.h>
+#include <stack>
+#include "Store.h"
+#include <filesystem>
+
+class ExportHsf :
+    public StoreVisitor
+{
+public:
+    ExportHsf(const char* path);
+    ~ExportHsf();
+
+    void beginFile(Node* group) override;
+
+    void endFile() override;
+
+    void beginModel(Node* group) override;
+
+    void endModel() override;
+
+    void beginGroup(struct Node* group) override;
+
+    void EndGroup() override;
+
+    void attribute(const char* key, const char* val) override;
+    void beginAttributes(struct Node* container) override;
+
+    void geometry(struct Geometry* geometry) override;
+
+public:
+    bool groupBoundingBoxes = false;
+    HC_KEY m_modelKey = 0;
+
+private:
+    std::filesystem::path m_savePath;
+    Map m_definedColors;
+    std::stack<HC_KEY> m_keyList;
+    Store* m_store = nullptr;
+    unsigned stack_p = 0;
+    unsigned off_v = 1;
+    unsigned off_n = 1;
+    unsigned off_t = 1;
+    struct Connectivity* m_conn = nullptr;
+    float curr_translation[3] = { 0,0,0 };
+
+    bool anchors = false;
+    bool primitiveBoundingBoxes = false;
+    bool compositeBoundingBoxes = false;
+
+};
+

--- a/src/ExportHsf.h
+++ b/src/ExportHsf.h
@@ -30,8 +30,14 @@ public:
 
     void attribute(const char* key, const char* val) override;
     void beginAttributes(struct Node* container) override;
+    void endAttributes(struct Node* container) override;
 
+    void beginGeometries(struct Node* container) override;
     void geometry(struct Geometry* geometry) override;
+    void endGeometries() override;
+
+    void beginChildren(struct Node* container) override;
+    void endChildren() override;
 
 public:
     bool groupBoundingBoxes = false;
@@ -56,6 +62,8 @@ private:
 
     int m_model_idx = 0;
     int m_group_idx = 0;
+
+    bool m_debugSign = false;
 
 };
 

--- a/src/ExportHsf.h
+++ b/src/ExportHsf.h
@@ -38,6 +38,7 @@ public:
     HC_KEY m_modelKey = 0;
 
 private:
+    HBaseModel* m_baseModel;
     std::filesystem::path m_savePath;
     Map m_definedColors;
     std::stack<HC_KEY> m_keyList;
@@ -52,6 +53,9 @@ private:
     bool anchors = false;
     bool primitiveBoundingBoxes = false;
     bool compositeBoundingBoxes = false;
+
+    int m_model_idx = 0;
+    int m_group_idx = 0;
 
 };
 

--- a/src/ParserRVM.cpp
+++ b/src/ParserRVM.cpp
@@ -73,6 +73,24 @@ namespace {
 
   const char* parse_chunk_header(char* id, uint32_t& next_chunk_offset, uint32_t& dunno, const char* curr_ptr, const char* end_ptr)
   {
+      if (curr_ptr >= end_ptr) 
+      {
+          id[0] = id[1] = id[2] = id[3] = ' ';
+          id[4] = 0;
+          next_chunk_offset = ~0u;
+          dunno = ~0u;
+          return curr_ptr;
+      }
+
+      if (curr_ptr[0] != 0 || curr_ptr[1] != 0 || curr_ptr[2] != 0) 
+      {
+          id[0] = id[1] = id[2] = id[3] = ' ';
+          id[4] = 0;
+          next_chunk_offset = ~0u;
+          dunno = ~0u;
+          return curr_ptr;
+      }
+
     unsigned i = 0;
     for (i = 0; i < 4 && curr_ptr + 4 <= end_ptr; i++) {
       assert(curr_ptr[0] == 0);

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -56,7 +56,9 @@ processFile(const std::string& path, F f)
 {
   bool rv = false;
 #ifdef _WIN32
-
+  char buf[MAX_PATH];
+  GetCurrentDirectoryA(MAX_PATH, buf);
+  logger(0, "Current directory: %s", buf);
   HANDLE h = CreateFileA(path.c_str(), GENERIC_READ, FILE_SHARE_READ, NULL, OPEN_EXISTING, FILE_ATTRIBUTE_NORMAL, NULL);
   if (h == INVALID_HANDLE_VALUE) {
     logger(2, "CreateFileA returned INVALID_HANDLE_VALUE");

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -34,6 +34,8 @@
 #include "AddGroupBBox.h"
 #include "Colorizer.h"
 
+#include "parserREV.h"
+
 
 void logger(unsigned level, const char* msg, ...)
 {
@@ -355,7 +357,7 @@ int main(int argc, char** argv)
     }
 
     // parse attributes file
-    if (arg_lc.rfind(".txt") != std::string::npos || arg_lc.rfind(".att")) {
+    if (arg_lc.rfind(".txt") != std::string::npos || arg_lc.rfind(".att") != std::string::npos) {
       if (processFile(arg, [store](const void* ptr, size_t size) { return parseAtt(store, logger, ptr, size); })) {
         fprintf(stderr, "Successfully parsed %s\n", arg.c_str());
       }
@@ -365,6 +367,20 @@ int main(int argc, char** argv)
         break;
       }
       continue;
+    }
+
+    // parse rev file
+    if (arg_lc.rfind(".rev") != std::string::npos) {
+        if (processFile(arg, [store, arg](const void* ptr, size_t size) { return parseREV(store, logger, arg.c_str(), ptr, size); }))
+        {
+            fprintf(stderr, "Successfully parsed %s\n", arg.c_str());
+        }
+        else {
+            fprintf(stderr, "Failed to parse %s: %s\n", arg.c_str(), store->errorString());
+            rv = -1;
+            break;
+        }
+        continue;
     }
   }
 

--- a/src/parserREV.cpp
+++ b/src/parserREV.cpp
@@ -1,0 +1,484 @@
+#include "Parser.h"
+#include "Store.h"
+#include "LinAlgOps.h"
+
+#include <cassert>
+#include <cctype>
+#include <cstdio>
+#include <cstdlib>
+#include <cstring>
+#include <string>
+#include <vector>
+#include <cstdarg>
+
+namespace {
+
+struct Context {
+  Store* store = nullptr;
+  Logger logger = nullptr;
+  const char* path = nullptr;
+
+  char* errbuf = nullptr;
+  size_t errbuf_size = 0;
+
+  // parent stack: [File] -> [Model]? -> [Group]? ...
+  std::vector<Node*> stack;
+};
+
+inline void set_error(Context* ctx, const char* fmt, ...)
+{
+  if (!ctx || !ctx->store) return;
+  if (!ctx->errbuf || ctx->errbuf_size == 0) {
+    ctx->store->setErrorString("parseREV: error");
+    return;
+  }
+  va_list ap;
+  va_start(ap, fmt);
+#if defined(_WIN32)
+  vsnprintf_s(ctx->errbuf, ctx->errbuf_size, _TRUNCATE, fmt, ap);
+#else
+  vsnprintf(ctx->errbuf, ctx->errbuf_size, fmt, ap);
+#endif
+  va_end(ap);
+  ctx->store->setErrorString(ctx->errbuf);
+}
+
+inline void skip_ws(const char*& p, const char* end)
+{
+  while (p < end && std::isspace(static_cast<unsigned char>(*p))) ++p;
+}
+
+inline bool read_u32(uint32_t& out, const char*& p, const char* end)
+{
+  skip_ws(p, end);
+  if (p >= end) return false;
+  char* ep = nullptr;
+  unsigned long v = std::strtoul(p, &ep, 10);
+  if (ep == p) return false;
+  if (v > 0xFFFFFFFFul) return false;
+  out = static_cast<uint32_t>(v);
+  p = ep;
+  return true;
+}
+
+inline bool read_f32(float& out, const char*& p, const char* end)
+{
+  skip_ws(p, end);
+  if (p >= end) return false;
+  char* ep = nullptr;
+  float v = std::strtof(p, &ep);
+  if (ep == p) return false;
+  out = v;
+  p = ep;
+  return true;
+}
+
+// Read one whole line (up to '\n'). Returns a string_view-like pair [s,e).
+// Does not include trailing '\r' or '\n'.
+inline bool read_line(const char*& line_s, const char*& line_e, const char*& p, const char* end)
+{
+  if (p >= end) return false;
+  line_s = p;
+  while (p < end && *p != '\n') ++p;
+  line_e = p;
+  if (p < end && *p == '\n') ++p; // consume '\n'
+  // trim trailing '\r'
+  if (line_e > line_s && *(line_e - 1) == '\r') --line_e;
+  return true;
+}
+
+inline std::string to_string_trim(const char* s, const char* e)
+{
+  // trim leading/trailing spaces for ID line; for content strings we keep spaces.
+  while (s < e && (*s == ' ' || *s == '\t')) ++s;
+  while (e > s && (*(e - 1) == ' ' || *(e - 1) == '\t')) --e;
+  return std::string(s, e);
+}
+
+inline const char* intern_line_as_string(Store* store, const char* s, const char* e)
+{
+  return store->strings.intern(s, e);
+}
+
+// Reads a chunk header:
+// - First line: chunk id (e.g., "HEAD", "MODL", "CNTB", "CNTE", "PRIM", "OBST", "INSU", "END:").
+// - Next: two uints on one line (as ExportRev prints "%6u%6u\n"), but we accept any whitespace between.
+inline bool read_chunk_header_txt(std::string& id, const char*& p, const char* end)
+{
+  const char *ls = nullptr, *le = nullptr;
+  if (!read_line(ls, le, p, end)) return false;
+  id = to_string_trim(ls, le);
+  // After the id line, there should be two uints
+  uint32_t u0 = 0, u1 = 0;
+  if (!read_u32(u0, p, end)) return false;
+  if (!read_u32(u1, p, end)) return false;
+
+  // Consume the rest of the line (up to '\n') if any digits were on this line.
+  // Our read_u32 skips whitespace automatically, so we may be already at '\n'.
+  // To be robust, read one optional trailing line break when the next char is '\r' or '\n'.
+  if (p < end) {
+    const char* tmp_s = nullptr;
+    const char* tmp_e = nullptr;
+    // Peek: if next non-space isn't a letter (i.e., still on same line), fast-forward to EOL.
+    // Simpler: if next char is '\r' or '\n', consume that line end.
+    if (*p == '\r' || *p == '\n') {
+      read_line(tmp_s, tmp_e, p, end); // will set tmp_s to current and move p past newline; not used
+    }
+  }
+  (void)u0; (void)u1; // currently unused (ExportRev writes 1,1)
+  return true;
+}
+
+bool parse_prim_txt(Context* ctx, const std::string& id, const char*& p, const char* end)
+{
+  // Parent must be a Group
+  if (ctx->stack.empty() || ctx->stack.back()->kind != Node::Kind::Group) {
+    set_error(ctx, "PRIM/OBST/INSU outside of a CNTB group");
+    return false;
+  }
+
+  uint32_t kind = 0;
+  if (!read_u32(kind, p, end)) { set_error(ctx, "PRIM: missing kind"); return false; }
+
+  auto* g = ctx->store->newGeometry(ctx->stack.back());
+
+  // type from chunk id
+  if (id == "PRIM") g->type = Geometry::Type::Primitive;
+  else if (id == "OBST") g->type = Geometry::Type::Obstruction;
+  else if (id == "INSU") g->type = Geometry::Type::Insulation;
+  else { set_error(ctx, "Unknown geometry chunk id '%s'", id.c_str()); return false; }
+
+  // Transparency is not present in text; inherit from parent group
+  g->transparency = ctx->stack.back()->group.transparency;
+
+  // Read 3 rows x 4 floats (ExportRev prints rows from column-major)
+  float r[3][4];
+  for (int i = 0; i < 3; ++i) {
+    if (!read_f32(r[i][0], p, end) || !read_f32(r[i][1], p, end) ||
+        !read_f32(r[i][2], p, end) || !read_f32(r[i][3], p, end)) {
+      set_error(ctx, "PRIM: missing matrix row %d", i);
+      return false;
+    }
+    // consume end of line if present
+    if (p < end && (*p == '\r' || *p == '\n')) {
+      const char *ls=nullptr,*le=nullptr; read_line(ls, le, p, end);
+    }
+  }
+  // Fill column-major 3x4: data indices: [0]=r0c0,[1]=r1c0,[2]=r2c0,[3]=r0c1,[4]=r1c1,[5]=r2c1,[6]=r0c2,[7]=r1c2,[8]=r2c2,[9]=r0c3,[10]=r1c3,[11]=r2c3
+  g->M_3x4.data[0] = r[0][0]; g->M_3x4.data[1] = r[1][0]; g->M_3x4.data[2] = r[2][0];
+  g->M_3x4.data[3] = r[0][1]; g->M_3x4.data[4] = r[1][1]; g->M_3x4.data[5] = r[2][1];
+  g->M_3x4.data[6] = r[0][2]; g->M_3x4.data[7] = r[1][2]; g->M_3x4.data[8] = r[2][2];
+  g->M_3x4.data[9] = r[0][3]; g->M_3x4.data[10] = r[1][3]; g->M_3x4.data[11] = r[2][3];
+
+  // Read bbox local: two vec3 lines
+  for (int i = 0; i < 6; ++i) {
+    if (!read_f32(g->bboxLocal.data[i], p, end)) { set_error(ctx, "PRIM: missing bboxLocal"); return false; }
+    // After each vec3 (i=2 and i=5), consume end of line if present
+    if (i == 2 || i == 5) {
+      if (p < end && (*p == '\r' || *p == '\n')) {
+        const char *ls=nullptr,*le=nullptr; read_line(ls, le, p, end);
+      }
+    }
+  }
+  g->bboxWorld = transform(g->M_3x4, g->bboxLocal);
+
+  switch (kind) {
+    case 1: // Pyramid
+      g->kind = Geometry::Kind::Pyramid;
+      if (!read_f32(g->pyramid.bottom[0], p, end) ||
+          !read_f32(g->pyramid.bottom[1], p, end) ||
+          !read_f32(g->pyramid.top[0],    p, end) ||
+          !read_f32(g->pyramid.top[1],    p, end)) { set_error(ctx, "Pyramid: bad bottom/top"); return false; }
+      if (p < end && (*p == '\r' || *p == '\n')) { const char *ls=nullptr,*le=nullptr; read_line(ls, le, p, end); }
+      if (!read_f32(g->pyramid.offset[0], p, end) ||
+          !read_f32(g->pyramid.offset[1], p, end) ||
+          !read_f32(g->pyramid.height,     p, end)) { set_error(ctx, "Pyramid: bad offset/height"); return false; }
+      if (p < end && (*p == '\r' || *p == '\n')) { const char *ls=nullptr,*le=nullptr; read_line(ls, le, p, end); }
+      break;
+
+    case 2: // Box
+      g->kind = Geometry::Kind::Box;
+      if (!read_f32(g->box.lengths[0], p, end) ||
+          !read_f32(g->box.lengths[1], p, end) ||
+          !read_f32(g->box.lengths[2], p, end)) { set_error(ctx, "Box: bad lengths"); return false; }
+      if (p < end && (*p == '\r' || *p == '\n')) { const char *ls=nullptr,*le=nullptr; read_line(ls, le, p, end); }
+      break;
+
+    case 3: // RectangularTorus
+      g->kind = Geometry::Kind::RectangularTorus;
+      if (!read_f32(g->rectangularTorus.inner_radius, p, end) ||
+          !read_f32(g->rectangularTorus.outer_radius, p, end) ||
+          !read_f32(g->rectangularTorus.height,       p, end) ||
+          !read_f32(g->rectangularTorus.angle,        p, end)) { set_error(ctx, "RectangularTorus: bad params"); return false; }
+      if (p < end && (*p == '\r' || *p == '\n')) { const char *ls=nullptr,*le=nullptr; read_line(ls, le, p, end); }
+      break;
+
+    case 4: // CircularTorus
+      g->kind = Geometry::Kind::CircularTorus;
+      if (!read_f32(g->circularTorus.offset, p, end) ||
+          !read_f32(g->circularTorus.radius, p, end) ||
+          !read_f32(g->circularTorus.angle,  p, end)) { set_error(ctx, "CircularTorus: bad params"); return false; }
+      if (p < end && (*p == '\r' || *p == '\n')) { const char *ls=nullptr,*le=nullptr; read_line(ls, le, p, end); }
+      break;
+
+    case 5: // EllipticalDish
+      g->kind = Geometry::Kind::EllipticalDish;
+      if (!read_f32(g->ellipticalDish.baseRadius, p, end) ||
+          !read_f32(g->ellipticalDish.height,     p, end)) { set_error(ctx, "EllipticalDish: bad params"); return false; }
+      if (p < end && (*p == '\r' || *p == '\n')) { const char *ls=nullptr,*le=nullptr; read_line(ls, le, p, end); }
+      break;
+
+    case 6: // SphericalDish
+      g->kind = Geometry::Kind::SphericalDish;
+      if (!read_f32(g->sphericalDish.baseRadius, p, end) ||
+          !read_f32(g->sphericalDish.height,     p, end)) { set_error(ctx, "SphericalDish: bad params"); return false; }
+      if (p < end && (*p == '\r' || *p == '\n')) { const char *ls=nullptr,*le=nullptr; read_line(ls, le, p, end); }
+      break;
+
+    case 7: // Snout
+      g->kind = Geometry::Kind::Snout;
+      if (!read_f32(g->snout.radius_b, p, end) ||
+          !read_f32(g->snout.radius_t, p, end) ||
+          !read_f32(g->snout.height,   p, end) ||
+          !read_f32(g->snout.offset[0],p, end) ||
+          !read_f32(g->snout.offset[1],p, end)) { set_error(ctx, "Snout: bad first line"); return false; }
+      if (p < end && (*p == '\r' || *p == '\n')) { const char *ls=nullptr,*le=nullptr; read_line(ls, le, p, end); }
+      if (!read_f32(g->snout.bshear[0], p, end) ||
+          !read_f32(g->snout.bshear[1], p, end) ||
+          !read_f32(g->snout.tshear[0], p, end) ||
+          !read_f32(g->snout.tshear[1], p, end)) { set_error(ctx, "Snout: bad shear"); return false; }
+      if (p < end && (*p == '\r' || *p == '\n')) { const char *ls=nullptr,*le=nullptr; read_line(ls, le, p, end); }
+      break;
+
+    case 8: // Cylinder
+      g->kind = Geometry::Kind::Cylinder;
+      if (!read_f32(g->cylinder.radius, p, end) ||
+          !read_f32(g->cylinder.height, p, end)) { set_error(ctx, "Cylinder: bad params"); return false; }
+      if (p < end && (*p == '\r' || *p == '\n')) { const char *ls=nullptr,*le=nullptr; read_line(ls, le, p, end); }
+      break;
+
+    case 9: // Sphere (ExportRev never writes this)
+      set_error(ctx, "Sphere (kind=9) not supported in text format");
+      return false;
+
+    case 10: // Line
+      g->kind = Geometry::Kind::Line;
+      if (!read_f32(g->line.a, p, end) ||
+          !read_f32(g->line.b, p, end)) { set_error(ctx, "Line: bad params"); return false; }
+      if (p < end && (*p == '\r' || *p == '\n')) { const char *ls=nullptr,*le=nullptr; read_line(ls, le, p, end); }
+      break;
+
+    case 11: { // FacetGroup
+      g->kind = Geometry::Kind::FacetGroup;
+
+      if (!read_u32(g->facetGroup.polygons_n, p, end)) { set_error(ctx, "FacetGroup: missing polygons_n"); return false; }
+      if (p < end && (*p == '\r' || *p == '\n')) { const char *ls=nullptr,*le=nullptr; read_line(ls, le, p, end); }
+
+      g->facetGroup.polygons = (Polygon*)ctx->store->arena.alloc(sizeof(Polygon) * g->facetGroup.polygons_n);
+      for (uint32_t pi = 0; pi < g->facetGroup.polygons_n; ++pi) {
+        auto& poly = g->facetGroup.polygons[pi];
+
+        if (!read_u32(poly.contours_n, p, end)) { set_error(ctx, "FacetGroup: missing contours_n"); return false; }
+        if (p < end && (*p == '\r' || *p == '\n')) { const char *ls=nullptr,*le=nullptr; read_line(ls, le, p, end); }
+
+        poly.contours = (Contour*)ctx->store->arena.alloc(sizeof(Contour) * poly.contours_n);
+        for (uint32_t ci = 0; ci < poly.contours_n; ++ci) {
+          auto& cont = poly.contours[ci];
+
+          if (!read_u32(cont.vertices_n, p, end)) { set_error(ctx, "FacetGroup: missing vertices_n"); return false; }
+          if (p < end && (*p == '\r' || *p == '\n')) { const char *ls=nullptr,*le=nullptr; read_line(ls, le, p, end); }
+
+          cont.vertices = (float*)ctx->store->arena.alloc(3 * sizeof(float) * cont.vertices_n);
+          cont.normals  = (float*)ctx->store->arena.alloc(3 * sizeof(float) * cont.vertices_n);
+
+          for (uint32_t vi = 0; vi < cont.vertices_n; ++vi) {
+            // vertex vec3
+            for (int k = 0; k < 3; ++k) {
+              if (!read_f32(cont.vertices[3 * vi + k], p, end)) { set_error(ctx, "FacetGroup: bad vertex"); return false; }
+            }
+            if (p < end && (*p == '\r' || *p == '\n')) { const char *ls=nullptr,*le=nullptr; read_line(ls, le, p, end); }
+            // normal vec3
+            for (int k = 0; k < 3; ++k) {
+              if (!read_f32(cont.normals[3 * vi + k], p, end)) { set_error(ctx, "FacetGroup: bad normal"); return false; }
+            }
+            if (p < end && (*p == '\r' || *p == '\n')) { const char *ls=nullptr,*le=nullptr; read_line(ls, le, p, end); }
+          }
+        }
+      }
+      break;
+    }
+
+    default:
+      set_error(ctx, "Unknown primitive kind %u", kind);
+      return false;
+  }
+
+  return true;
+}
+
+bool parse_cntb_txt(Context* ctx, const char*& p, const char* end)
+{
+  // Parent must exist (Model or Group)
+  if (ctx->stack.empty() || (ctx->stack.back()->kind != Node::Kind::Model && ctx->stack.back()->kind != Node::Kind::Group)) {
+    set_error(ctx, "CNTB without valid parent (Model/Group)");
+    return false;
+  }
+
+  auto* parent = ctx->stack.back();
+  Node* g = ctx->store->newNode(parent, Node::Kind::Group);
+
+  // Inherit transparency if parent is Group (same as parseRVM)
+  if (parent->kind == Node::Kind::Group) {
+    g->group.transparency = parent->group.transparency;
+  }
+
+  // name (full line)
+  const char *ls = nullptr, *le = nullptr;
+  if (!read_line(ls, le, p, end)) { set_error(ctx, "CNTB: missing name"); return false; }
+  g->group.name = intern_line_as_string(ctx->store, ls, le);
+
+  // translation vec3 in mm -> convert to meters
+  if (!read_f32(g->group.translation[0], p, end) ||
+      !read_f32(g->group.translation[1], p, end) ||
+      !read_f32(g->group.translation[2], p, end)) { set_error(ctx, "CNTB: missing translation"); return false; }
+  g->group.translation[0] *= 0.001f;
+  g->group.translation[1] *= 0.001f;
+  g->group.translation[2] *= 0.001f;
+  if (p < end && (*p == '\r' || *p == '\n')) { read_line(ls, le, p, end); }
+
+  // material
+  if (!read_u32(g->group.material, p, end)) { set_error(ctx, "CNTB: missing material"); return false; }
+  if (p < end && (*p == '\r' || *p == '\n')) { read_line(ls, le, p, end); }
+
+  ctx->stack.push_back(g);
+
+  // Children: loop until CNTE
+  while (p < end) {
+    std::string cid;
+    if (!read_chunk_header_txt(cid, p, end)) { set_error(ctx, "CNTB: unexpected EOF while reading children"); return false; }
+    if (cid == "CNTE") {
+      // No extra payload in text; balanced end of group
+      break;
+    } else if (cid == "CNTB") {
+      if (!parse_cntb_txt(ctx, p, end)) return false;
+    } else if (cid == "PRIM" || cid == "OBST" || cid == "INSU") {
+      if (!parse_prim_txt(ctx, cid, p, end)) return false;
+    } else {
+      set_error(ctx, "CNTB: unexpected chunk '%s'", cid.c_str());
+      return false;
+    }
+  }
+
+  ctx->stack.pop_back();
+  return true;
+}
+
+bool parse_modl_txt(Context* ctx, const char*& p, const char* end)
+{
+  // Parent must be File
+  if (ctx->stack.empty() || ctx->stack.back()->kind != Node::Kind::File) {
+    set_error(ctx, "MODL without HEAD/File");
+    return false;
+  }
+
+  // If previous top is Model, pop it (since MODL has no explicit end marker)
+  if (ctx->stack.back()->kind == Node::Kind::Model) {
+    ctx->stack.pop_back();
+  }
+
+  auto* m = ctx->store->newNode(ctx->stack.back(), Node::Kind::Model);
+  ctx->stack.push_back(m);
+
+  // project and name (each a full line)
+  const char *ls = nullptr, *le = nullptr;
+  if (!read_line(ls, le, p, end)) { set_error(ctx, "MODL: missing project"); return false; }
+  m->model.project = intern_line_as_string(ctx->store, ls, le);
+  if (!read_line(ls, le, p, end)) { set_error(ctx, "MODL: missing name"); return false; }
+  m->model.name = intern_line_as_string(ctx->store, ls, le);
+
+  return true;
+}
+
+bool parse_head_txt(Context* ctx, const char*& p, const char* end)
+{
+  // Start a new File node and push to stack
+  if (!ctx->stack.empty()) {
+    set_error(ctx, "HEAD encountered but stack not empty");
+    return false;
+  }
+  auto* f = ctx->store->newNode(nullptr, Node::Kind::File);
+  ctx->stack.push_back(f);
+
+  const char *ls = nullptr, *le = nullptr;
+  if (!read_line(ls, le, p, end)) { set_error(ctx, "HEAD: missing info"); return false; }
+  f->file.info = intern_line_as_string(ctx->store, ls, le);
+  if (!read_line(ls, le, p, end)) { set_error(ctx, "HEAD: missing note"); return false; }
+  f->file.note = intern_line_as_string(ctx->store, ls, le);
+  if (!read_line(ls, le, p, end)) { set_error(ctx, "HEAD: missing date"); return false; }
+  f->file.date = intern_line_as_string(ctx->store, ls, le);
+  if (!read_line(ls, le, p, end)) { set_error(ctx, "HEAD: missing user"); return false; }
+  f->file.user = intern_line_as_string(ctx->store, ls, le);
+
+  // No version/encoding in text; set encoding empty, set path
+  f->file.encoding = ctx->store->strings.intern("");
+  f->file.path = ctx->store->strings.intern(ctx->path ? ctx->path : "");
+
+  return true;
+}
+
+} // namespace
+
+bool parseREV(Store* store, Logger logger, const char* path, const void* ptr, size_t size)
+{
+  char buf[1024];
+  Context ctx;
+  ctx.store = store;
+  ctx.logger = logger;
+  ctx.path = path;
+  ctx.errbuf = buf;
+  ctx.errbuf_size = sizeof(buf);
+
+  const char* base = reinterpret_cast<const char*>(ptr);
+  const char* p = base;
+  const char* end = base + size;
+
+  // First chunk must be HEAD
+  std::string id;
+  if (!read_chunk_header_txt(id, p, end)) { set_error(&ctx, "Empty or invalid file"); return false; }
+  if (id != "HEAD") { set_error(&ctx, "Expected HEAD, got '%s'", id.c_str()); return false; }
+  if (!parse_head_txt(&ctx, p, end)) return false;
+
+  // Next chunks: MODL, CNTB..., END:
+  while (p < end) {
+    if (!read_chunk_header_txt(id, p, end)) { set_error(&ctx, "Unexpected EOF while reading top-level chunks"); return false; }
+    if (id == "END:") {
+      // Pop model if left on stack
+      if (!ctx.stack.empty() && ctx.stack.back()->kind == Node::Kind::Model) ctx.stack.pop_back();
+      break;
+    } else if (id == "MODL") {
+      if (!parse_modl_txt(&ctx, p, end)) return false;
+    } else if (id == "CNTB") {
+      if (!parse_cntb_txt(&ctx, p, end)) return false;
+    } else if (id == "CNTE") {
+      // Some producers might put stray CNTE (rare). We can skip but warn.
+      ctx.logger(1, "parseREV: Unexpected CNTE at root level, ignoring.");
+    } else if (id == "PRIM" || id == "OBST" || id == "INSU") {
+      // Should not appear at root; but if it does, error
+      set_error(&ctx, "Geometry chunk '%s' outside of any group", id.c_str());
+      return false;
+    } else {
+      set_error(&ctx, "Unrecognized chunk '%s'", id.c_str());
+      return false;
+    }
+  }
+
+  // Clean stack: should have just [File] or empty after popping
+  if (!ctx.stack.empty() && ctx.stack.back()->kind == Node::Kind::Model) ctx.stack.pop_back();
+  if (!ctx.stack.empty() && ctx.stack.back()->kind == Node::Kind::File) ctx.stack.pop_back();
+  if (!ctx.stack.empty()) {
+    ctx.logger(1, "parseREV: non-empty stack at end (ignored)");
+  }
+
+  store->updateCounts();
+  return true;
+}

--- a/src/parserREV.h
+++ b/src/parserREV.h
@@ -1,0 +1,10 @@
+#pragma once
+#include "Common.h"
+
+class Store;
+
+// 已有的 parseRVM 等声明...
+// bool parseRVM(Store* store, Logger logger, const char* path, const void* ptr, size_t size);
+
+// 新增：从 ExportRev 生成的文本格式解析到 Store
+bool parseREV(Store* store, Logger logger, const char* path, const void* ptr, size_t size);


### PR DESCRIPTION
**Description:**
This PR introduces two main updates to the project:

1. **New `parserREV` (parserREV.h / parserREV.cpp)**

   * Added a dedicated parser for `.rev` files (text-based format converted from `.rvm`).
   * Also supports `.txt` files, since the `.rev` format can be opened/edited as plain text.

2. **Improved error handling in `parserRVM`**

   * Some `.rev` files can be renamed to `.rvm` and opened with Navisworks, but they will cause errors in `parserRVM`.
   * Added exception handling to gracefully handle such cases, preventing crashes when a `.rev` file is misused as `.rvm`.

**Benefit:**

* Expands format support (`.rev` / `.txt`) for better usability.
* Makes `parserRVM` more robust and user-friendly when dealing with mislabeled files.
Fixes #63